### PR TITLE
added null reference check for getOSVirtualHardDisk() to avoid crash on subscriptions with role-based cloud services

### DIFF
--- a/plugin-azure-server-asm/src/main/java/jetbrains/buildServer/clouds/azure/asm/connector/AzureApiConnector.java
+++ b/plugin-azure-server-asm/src/main/java/jetbrains/buildServer/clouds/azure/asm/connector/AzureApiConnector.java
@@ -281,7 +281,10 @@ public class AzureApiConnector extends AzureApiConnectorBase<AzureCloudImage, Az
                 for (HostedServiceGetDetailedResponse.Deployment deployment : response.getDeployments()) {
                     final Map<String, String> roleOsNames = new HashMap<>();
                     for (Role role : deployment.getRoles()) {
-                        roleOsNames.put(role.getRoleName(), role.getOSVirtualHardDisk().getOperatingSystem());
+                        if (role.getOSVirtualHardDisk() != null)
+                        {
+                            roleOsNames.put(role.getRoleName(), role.getOSVirtualHardDisk().getOperatingSystem());
+                        }
                     }
                     for (RoleInstance instance : deployment.getRoleInstances()) {
                         instances.put(instance.getInstanceName(), roleOsNames.get(instance.getRoleName()));


### PR DESCRIPTION
Fix for #28 - added null-reference check to prevent plugin from crash on package-based service response.