### PR TITLE
Lower case VmPrefix before comparison

### DIFF
--- a/plugin-azure-server-arm/src/main/java/jetbrains/buildServer/clouds/azure/arm/connector/AzureApiConnectorImpl.java
+++ b/plugin-azure-server-arm/src/main/java/jetbrains/buildServer/clouds/azure/arm/connector/AzureApiConnectorImpl.java
@@ -252,7 +252,7 @@ public class AzureApiConnectorImpl extends AzureApiConnectorBase<AzureCloudImage
             public void onDone(List<VirtualMachine> machines) {
                 for (VirtualMachine virtualMachine : machines) {
                     final String name = virtualMachine.name();
-                    if (!name.startsWith(details.getVmNamePrefix())) {
+                    if (!name.startsWith(details.getVmNamePrefix().toLowerCase())) {
                         LOG.debug("Ignore vm with name " + name);
                         continue;
                     }
@@ -276,7 +276,7 @@ public class AzureApiConnectorImpl extends AzureApiConnectorBase<AzureCloudImage
                     }
 
                     final String sourceName = tags.get(AzureConstants.TAG_SOURCE);
-                    if (!StringUtil.areEqual(sourceName, details.getSourceName())) {
+                    if (!StringUtil.areEqual(sourceName, details.getSourceName().toLowerCase())) {
                         LOG.debug("Ignore vm with invalid source tag " + sourceName);
                         continue;
                     }


### PR DESCRIPTION
If a user enters a name in the user interface with not all lower case letters the AzureApiConnectorImpl will not find the lower case named instance since the comparisons were case sensitive.